### PR TITLE
Ignore fixture files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,6 @@ before_install:
   - go get github.com/mattn/goveralls
 
 script:
-  - |
-    for pkg in $(go list ./... | grep -v vendor)
-    do
-      cd $GOPATH/src/$pkg/
-      go vet
-      go test -cover -coverprofile coverage.out
-    done
-  - cd $TRAVIS_BUILD_DIR
-  - $GOPATH/bin/goveralls -service=travis-ci
+  - go test artifactory/*.go -cover -coverprofile artifactory-coverage.out
+  - go test xray/*.go -cover -coverprofile xray-coverage.out
+  - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=artifactory-coverage.out,xray-coverage.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ before_install:
   - go get github.com/mattn/goveralls
 
 script:
-  - go test artifactory/*.go -cover -coverprofile artifactory-coverage.out
-  - go test xray/*.go -cover -coverprofile xray-coverage.out
-  - $GOPATH/bin/goveralls -service=travis-ci -ignore='artifactory/fixtures/,xray/fixtures/'
+  - go test artifactory/*.go -cover -coverprofile artifactory/coverage.out
+  - go test xray/*.go -cover -coverprofile xray/coverage.out
+  - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=artifactory/coverage.out,xray/coverage.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ before_install:
 script:
   - go test artifactory/*.go -cover -coverprofile artifactory-coverage.out
   - go test xray/*.go -cover -coverprofile xray-coverage.out
-  - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=artifactory-coverage.out,xray-coverage.out
+  - $GOPATH/bin/goveralls -service=travis-ci -ignore='artifactory/fixtures/,xray/fixtures/'


### PR DESCRIPTION
Couple of changes for this PR:

- Simplify `go test` commands
- Have [goveralls](https://github.com/mattn/goveralls) ignore `artifactory/fixtures/*.go` and `xray/fixtures/*.go`