### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,23 +13,23 @@ We'd love to accept your contributions to this project! There are just a few sma
 These rules must be followed for any contributions to be merged into master. A Git installation is required.
 
 1. Fork this repo
-1. Go get the original code:
+2. Go get the original code:
 
   `go get github.com/target/go-arty`
 
-1. Navigate to the original code:
+3. Navigate to the original code:
 
   `$GOPATH/src/github.com/target/go-arty`
 
-1. Add a remote branch pointing to your fork:
+4. Add a remote branch pointing to your fork:
 
   `git remote add fork https://github.com/your_fork/go-arty`
 
-1. Implement desired changes
-1. Validate the changes meet your desired use case
-1. Write tests around the changes you made
-1. Update documentation
-1. Please run the below commands:
+5. Implement desired changes
+6. Validate the changes meet your desired use case
+7. Write tests around the changes you made
+8. Update documentation
+9. Please run the below commands:
 
 ```sh
 # Generate necessary code
@@ -45,8 +45,8 @@ go fmt github.com/target/go-arty/...
 go vet github.com/target/go-arty/...
 ```
 
-1. Push to your fork:
+10. Push to your fork:
 
   `git push fork master`
 
-1. Open a pull request. Thank you for your contribution! A dialog will ensue.
+11. Open a pull request. Thank you for your contribution! A dialog will ensue.


### PR DESCRIPTION
While I typically like to use `1.` to let markdown/github handle the automatic numbering it looks like it ran into some issues due to the code blocks, so I opted to just leave indentation alone and move towards utilizing `1.`, `2.`, etc.