### PR TITLE
add matrix param support on upload op

### DIFF
--- a/artifactory/artifacts.go
+++ b/artifactory/artifacts.go
@@ -69,7 +69,7 @@ func (s *ArtifactsService) Upload(repo, path, file string, properties map[string
 		if len(v) == 1 {
 			propertyString = propertyString + fmt.Sprintf("%s=%s", k, v[0])
 		} else {
-			propertyString = propertyString + fmt.Sprintf("%s=[%s]", k, strings.Join(v, ","))
+			propertyString = propertyString + fmt.Sprintf("%s=%s", k, strings.Join(v, ","))
 		}
 
 		if index != len(properties) {
@@ -77,7 +77,7 @@ func (s *ArtifactsService) Upload(repo, path, file string, properties map[string
 		}
 	}
 
-	u := fmt.Sprintf("/%s/%s/%s", repo, path, file)
+	u := fmt.Sprintf("/%s/%s/%s;%s", repo, path, file, propertyString)
 	v := new(string)
 
 	data, err := os.Open(file)

--- a/artifactory/artifacts_test.go
+++ b/artifactory/artifacts_test.go
@@ -17,6 +17,7 @@
 package artifactory
 
 import (
+	"strings"
 	"encoding/json"
 	"io/ioutil"
 	"net/http/httptest"
@@ -115,7 +116,8 @@ func Test_Artifacts(t *testing.T) {
 				actual, resp, err := c.Artifacts.Upload("local-repo1", "folder", "fixtures/artifacts/foo.txt", map[string][]string{"key": []string{"value", "value2", "value3"}, "key2": []string{"anothervalue"}})
 				g.Assert(actual != nil).IsTrue()
 				g.Assert(resp != nil).IsTrue()
-				g.Assert(resp.Request.URL.Path).Equal("/local-repo1/folder/fixtures/artifacts/foo.txt;key=value,value2,value3;key2=anothervalue")
+				g.Assert(strings.Contains(resp.Request.URL.Path, "key=value,value2,value3")).IsTrue()
+				g.Assert(strings.Contains(resp.Request.URL.Path, "key2=anothervalue")).IsTrue()
 				g.Assert(err == nil).IsTrue()
 			})
 

--- a/artifactory/artifacts_test.go
+++ b/artifactory/artifacts_test.go
@@ -90,6 +90,7 @@ func Test_Artifacts(t *testing.T) {
 				actual, resp, err := c.Artifacts.Upload("local-repo1", "folder", "fixtures/artifacts/foo.txt", map[string][]string{"key": []string{"value"}})
 				g.Assert(actual != nil).IsTrue()
 				g.Assert(resp != nil).IsTrue()
+				g.Assert(resp.Request.URL.Path).Equal("/local-repo1/folder/fixtures/artifacts/foo.txt;key=value")
 				g.Assert(err == nil).IsTrue()
 				g.Assert(*actual).Equal("")
 			})
@@ -106,6 +107,7 @@ func Test_Artifacts(t *testing.T) {
 				actual, resp, err := c.Artifacts.Upload("local-repo1", "folder", "fixtures/artifacts/foo.txt", map[string][]string{"key": []string{"value", "value2", "value3"}})
 				g.Assert(actual != nil).IsTrue()
 				g.Assert(resp != nil).IsTrue()
+				g.Assert(resp.Request.URL.Path).Equal("/local-repo1/folder/fixtures/artifacts/foo.txt;key=value,value2,value3")
 				g.Assert(err == nil).IsTrue()
 			})
 
@@ -113,6 +115,7 @@ func Test_Artifacts(t *testing.T) {
 				actual, resp, err := c.Artifacts.Upload("local-repo1", "folder", "fixtures/artifacts/foo.txt", map[string][]string{"key": []string{"value", "value2", "value3"}, "key2": []string{"anothervalue"}})
 				g.Assert(actual != nil).IsTrue()
 				g.Assert(resp != nil).IsTrue()
+				g.Assert(resp.Request.URL.Path).Equal("/local-repo1/folder/fixtures/artifacts/foo.txt;key=value,value2,value3;key2=anothervalue")
 				g.Assert(err == nil).IsTrue()
 			})
 


### PR DESCRIPTION
Believe I found a bug for matrix param support; `propertyString` wasn't being appended to the PUT URL. I added it and updated tests to reflect the URL build changes. I followed the docs [here](https://www.jfrog.com/confluence/display/RTF/Using+Properties+in+Deployment+and+Resolution#UsingPropertiesinDeploymentandResolution-DynamicallyAddingPropertiestoArtifactsonDeployment) on the multi-value property change.