### PR TITLE
add PackageType to Repositories.GetAll

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,6 @@ Found something that doesn't seem right or have a feature request? [Please open 
 
 ## Copyright and License
 
-[![license](https://img.shields.io/github/license/mashape/apistatus.svg)](LICENSE)
+[![license](https://img.shields.io/crates/l/gl.svg)](LICENSE)
 
 Copyright (c) 2018 Target Brands, Inc.

--- a/artifactory/artifactory-accessors.go
+++ b/artifactory/artifactory-accessors.go
@@ -1367,6 +1367,14 @@ func (r *Repository) GetKey() string {
 	return *r.Key
 }
 
+// GetPackageType returns the PackageType field if it's non-nil, zero value otherwise.
+func (r *Repository) GetPackageType() string {
+	if r == nil || r.PackageType == nil {
+		return ""
+	}
+	return *r.PackageType
+}
+
 // GetType returns the Type field if it's non-nil, zero value otherwise.
 func (r *Repository) GetType() string {
 	if r == nil || r.Type == nil {

--- a/artifactory/fixtures/repositories/repositories.json
+++ b/artifactory/fixtures/repositories/repositories.json
@@ -1,14 +1,16 @@
 [
   {
-    "key" : "libs-releases-local",
-    "type" : "LOCAL",
-    "description" : "Local repository for in-house libraries",
-    "url" : "http://localhost:8081/artifactory/libs-releases-local"
+    "key": "libs-releases-local",
+    "type": "LOCAL",
+    "description": "Local repository for in-house libraries",
+    "url": "http://localhost:8081/artifactory/libs-releases-local",
+    "packageType": "NuGet"
   },
   {
-    "key" : "libs-snapshots-local",
-    "type" : "LOCAL",
-    "description" : "Local repository for in-house snapshots",
-    "url" : "http://localhost:8081/artifactory/libs-snapshots-local"
+    "key": "libs-snapshots-local",
+    "type": "LOCAL",
+    "description": "Local repository for in-house snapshots",
+    "url": "http://localhost:8081/artifactory/libs-snapshots-local",
+    "packageType": "Docker"
   }
 ]

--- a/artifactory/repositories.go
+++ b/artifactory/repositories.go
@@ -36,6 +36,7 @@ type Repository struct {
 	Type        *string `json:"type,omitempty"`
 	Description *string `json:"description,omitempty"`
 	URL         *string `json:"url,omitempty"`
+	PackageType *string `json:"packageType,omitempty"`
 }
 
 func (r Repository) String() string {

--- a/artifactory/repositories_test.go
+++ b/artifactory/repositories_test.go
@@ -57,6 +57,7 @@ func Test_Repositories(t *testing.T) {
 					Type:        String("LOCAL"),
 					Description: String("Local repository for in-house libraries"),
 					URL:         String("http://localhost:8081/artifactory/libs-releases-local"),
+					PackageType: String("NuGet"),
 				}
 
 				data, _ := ioutil.ReadFile("fixtures/repositories/repositories.json")
@@ -149,10 +150,10 @@ func Test_Repositories(t *testing.T) {
 						BlackedOut:                   Bool(false),
 						PropertySets:                 &[]string{"ps1", "ps2"},
 					},
-					URL:      String("http://host:port/some-repo"),
-					Username: String("remote-repo-user"),
-					Password: String("pass"),
-					Proxy:    String("proxy1"),
+					URL:                               String("http://host:port/some-repo"),
+					Username:                          String("remote-repo-user"),
+					Password:                          String("pass"),
+					Proxy:                             String("proxy1"),
 					RemoteRepoChecksumPolicyType:      String("generate-if-absent"),
 					HardFail:                          Bool(false),
 					Offline:                           Bool(false),
@@ -201,10 +202,10 @@ func Test_Repositories(t *testing.T) {
 						IncludesPattern: String("**/*"),
 						ExcludesPattern: String(""),
 					},
-					Repositories:                                  &[]string{"local-repo1", "local-repo2", "remote-repo1", "virtual-repo2"},
-					DebianTrivialLayout:                           Bool(false),
+					Repositories:        &[]string{"local-repo1", "local-repo2", "remote-repo1", "virtual-repo2"},
+					DebianTrivialLayout: Bool(false),
 					ArtifactoryRequestsCanRetrieveRemoteArtifacts: Bool(false),
-					KeyPair: String("keypair1"),
+					KeyPair:                              String("keypair1"),
 					PomRepositoryReferencesCleanupPolicy: String("discard_active_reference"),
 					DefaultDeploymentRepo:                String("local-repo1"),
 				}


### PR DESCRIPTION
Currently, the Repositories.GetAll function does not properly return the same response as the [api/repositories](https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-GetRepositories) endpoint. This PR aims to have the library match the response from the endpoint.

Sample payload to show that `packageType` is valid:

Request:
```sh
curl --request GET \
  --url https://company.com/artifactory/api/repositories \
  --header 'x-jfrog-art-api: <token>'
```

Response:
```json
[
  {
    "key": "foo",
    "type": "LOCAL",
    "url": "https://company.com/artifactory/foo",
    "packageType": "Generic"
  },
  {
    "key": "bar",
    "type": "LOCAL",
    "url": "https://company.com/artifactory/bar",
    "packageType": "NuGet"
  }
]
```

I also updated the readme to include the correct license logo.