### PR TITLE
Add "xrayIndex" field to local and remote structs

### DIFF
--- a/artifactory/artifactory-accessors.go
+++ b/artifactory/artifactory-accessors.go
@@ -975,6 +975,14 @@ func (l *LocalRepository) GetSnapshotVersionBehavior() string {
 	return *l.SnapshotVersionBehavior
 }
 
+// GetXrayIndex returns the XrayIndex field if it's non-nil, zero value otherwise.
+func (l *LocalRepository) GetXrayIndex() bool {
+	if l == nil || l.XrayIndex == nil {
+		return false
+	}
+	return *l.XrayIndex
+}
+
 // GetYumRootDepth returns the YumRootDepth field if it's non-nil, zero value otherwise.
 func (l *LocalRepository) GetYumRootDepth() int {
 	if l == nil || l.YumRootDepth == nil {
@@ -1285,6 +1293,14 @@ func (r *RemoteRepository) GetVcsType() string {
 		return ""
 	}
 	return *r.VcsType
+}
+
+// GetXrayIndex returns the XrayIndex field if it's non-nil, zero value otherwise.
+func (r *RemoteRepository) GetXrayIndex() bool {
+	if r == nil || r.XrayIndex == nil {
+		return false
+	}
+	return *r.XrayIndex
 }
 
 // GetFilesCount returns the FilesCount field if it's non-nil, zero value otherwise.

--- a/artifactory/fixtures/repositories/local_repository.json
+++ b/artifactory/fixtures/repositories/local_repository.json
@@ -22,5 +22,6 @@
   "yumRootDepth" : 0,
   "dockerApiVersion" : "V2",
   "enableFileListsIndexing" : "false",
-  "optionalIndexCompressionFormats" : ["bz2", "lzma", "xz"]
+  "optionalIndexCompressionFormats" : ["bz2", "lzma", "xz"],
+  "xrayIndex" : false
 }

--- a/artifactory/fixtures/repositories/remote_repository.json
+++ b/artifactory/fixtures/repositories/remote_repository.json
@@ -43,5 +43,6 @@
   "vcsGitProvider": "CUSTOM",
   "vcsGitDownloadUrl": "",
   "bypassHeadRequest" : false,
-  "clientTlsCertificate": ""
+  "clientTlsCertificate": "",
+  "xrayIndex" : false
 }

--- a/artifactory/repositories.go
+++ b/artifactory/repositories.go
@@ -81,6 +81,7 @@ type LocalRepository struct {
 	DockerAPIVersion                *string   `json:"dockerApiVersion,omitempty"`
 	EnableFileListsIndexing         *bool     `json:"enableFileListsIndexing,omitempty"`
 	OptionalIndexCompressionFormats *[]string `json:"optionalIndexCompressionFormats,omitempty"`
+	XrayIndex                       *bool     `json:"xrayIndex,omitempty"`
 }
 
 func (l LocalRepository) String() string {
@@ -124,6 +125,7 @@ type RemoteRepository struct {
 	VcsGitDownloadUrl                 *string `json:"VcsGitDownloadUrl,omitempty"`
 	BypassHeadRequest                 *bool   `json:"bypassHeadRequest,omitempty"`
 	ClientTLSCertificate              *string `json:"clientTlsCertificate,omitempty"`
+	XrayIndex                         *bool   `json:"xrayIndex,omitempty"`
 }
 
 func (r RemoteRepository) String() string {

--- a/artifactory/repositories_test.go
+++ b/artifactory/repositories_test.go
@@ -122,6 +122,7 @@ func Test_Repositories(t *testing.T) {
 					DockerAPIVersion:                String("V2"),
 					EnableFileListsIndexing:         Bool(false),
 					OptionalIndexCompressionFormats: &[]string{"bz2", "lzma", "xz"},
+					XrayIndex:                       Bool(false),
 				}
 
 				data, _ := ioutil.ReadFile("fixtures/repositories/local_repository.json")
@@ -181,6 +182,7 @@ func Test_Repositories(t *testing.T) {
 					VcsGitDownloadUrl:                 String(""),
 					BypassHeadRequest:                 Bool(false),
 					ClientTLSCertificate:              String(""),
+					XrayIndex:                         Bool(false),
 				}
 
 				data, _ := ioutil.ReadFile("fixtures/repositories/remote_repository.json")


### PR DESCRIPTION
Provide the `xrayIndex` field for requests to enable Xray indexing for local and remote repositories.