### PR TITLE
fix(xray summary): include cves in struct response

### DIFF
--- a/xray/fixtures/summary/summary.json
+++ b/xray/fixtures/summary/summary.json
@@ -15,6 +15,11 @@
           "issue_type": "security",
           "severity": "Major",
           "provider": "JFrog",
+          "cves": [
+            {
+              "cve": "CVE-2016-6251"
+            }
+          ],
           "created": "2016-10-26T11:15:51.17Z",
           "impact_path": [
             "xray-artifactory/maven-1000/com/atlassian/aui/auiplugin/0.0.5-9-0-snapshot-035-do-not-use/Jinja2-2.7.2"

--- a/xray/summary.go
+++ b/xray/summary.go
@@ -45,15 +45,21 @@ type SummaryArtifact struct {
 	Licenses *[]SummaryLicense `json:"licenses,omitempty"`
 }
 
+// SummaryCve resprents the cves within the summary from Xray
+type SummaryCve struct {
+	Cve *string `json:"cve,omitempty"`
+}
+
 // SummaryIssue represents a issue within the summary in Xray.
 type SummaryIssue struct {
-	Created     *string   `json:"created,omitempty"`
-	Description *string   `json:"description,omitempty"`
-	ImpactPath  *[]string `json:"impact_path,omitempty"`
-	IssueType   *string   `json:"issue_type,omitempty"`
-	Provider    *string   `json:"provider,omitempty"`
-	Severity    *string   `json:"severity,omitempty"`
-	Summary     *string   `json:"summary,omitempty"`
+	Created     *string       `json:"created,omitempty"`
+	Description *string       `json:"description,omitempty"`
+	ImpactPath  *[]string     `json:"impact_path,omitempty"`
+	IssueType   *string       `json:"issue_type,omitempty"`
+	Provider    *string       `json:"provider,omitempty"`
+	Cves        *[]SummaryCve `json:"cves,omitempty"`
+	Severity    *string       `json:"severity,omitempty"`
+	Summary     *string       `json:"summary,omitempty"`
 }
 
 // SummaryGeneral represents the general information of a summary in Xray.

--- a/xray/summary_test.go
+++ b/xray/summary_test.go
@@ -64,8 +64,13 @@ func Test_Summary(t *testing.T) {
 									IssueType:   String("security"),
 									Severity:    String("Major"),
 									Provider:    String("JFrog"),
-									Created:     String("2016-10-26T11:15:51.17Z"),
-									ImpactPath:  &[]string{"xray-artifactory/maven-1000/com/atlassian/aui/auiplugin/0.0.5-9-0-snapshot-035-do-not-use/Jinja2-2.7.2"},
+									Cves: &[]SummaryCve{
+										SummaryCve{
+											Cve: String("CVE-2016-6251"),
+										},
+									},
+									Created:    String("2016-10-26T11:15:51.17Z"),
+									ImpactPath: &[]string{"xray-artifactory/maven-1000/com/atlassian/aui/auiplugin/0.0.5-9-0-snapshot-035-do-not-use/Jinja2-2.7.2"},
 								},
 							},
 							Licenses: &[]SummaryLicense{

--- a/xray/xray-accessors.go
+++ b/xray/xray-accessors.go
@@ -567,6 +567,14 @@ func (s *SummaryArtifactRequest) GetPaths() []string {
 	return *s.Paths
 }
 
+// GetCve returns the Cve field if it's non-nil, zero value otherwise.
+func (s *SummaryCve) GetCve() string {
+	if s == nil || s.Cve == nil {
+		return ""
+	}
+	return *s.Cve
+}
+
 // GetError returns the Error field if it's non-nil, zero value otherwise.
 func (s *SummaryError) GetError() string {
 	if s == nil || s.Error == nil {
@@ -629,6 +637,14 @@ func (s *SummaryIssue) GetCreated() string {
 		return ""
 	}
 	return *s.Created
+}
+
+// GetCves returns the Cves field if it's non-nil, zero value otherwise.
+func (s *SummaryIssue) GetCves() []SummaryCve {
+	if s == nil || s.Cves == nil {
+		return nil
+	}
+	return *s.Cves
 }
 
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.


### PR DESCRIPTION
Xray usually returns a list of cves when it responds with the issues so we should handle data structure and pass that back to the user.