### PR TITLE
feat(v2): add first endpoint for permissions

### DIFF
--- a/artifactory/client.go
+++ b/artifactory/client.go
@@ -53,6 +53,7 @@ type Client struct {
 	Groups         *GroupsService
 	Licenses       *LicensesService
 	Permissions    *PermissionsService
+	PermissionsV2  *PermissionsServiceV2
 	Repositories   *RepositoriesService
 	Search         *SearchService
 	Storage        *StorageService
@@ -93,6 +94,7 @@ func NewClient(baseUrl string, httpClient *http.Client) (*Client, error) {
 	c.Groups = &GroupsService{client: c}
 	c.Licenses = &LicensesService{client: c}
 	c.Permissions = &PermissionsService{client: c}
+	c.PermissionsV2 = &PermissionsServiceV2{client: c}
 	c.Repositories = &RepositoriesService{client: c}
 	c.Search = &SearchService{client: c}
 	c.Storage = &StorageService{client: c}

--- a/artifactory/fixtures/permissions/handler.go
+++ b/artifactory/fixtures/permissions/handler.go
@@ -20,6 +20,7 @@ func FakeHandler() http.Handler {
 	e.GET("/api/security/permissions/:target", getPermission)
 	e.PUT("/api/security/permissions/:target", createPermission)
 	e.DELETE("/api/security/permissions/:target", deletePermission)
+	e.HEAD("/api/v2/security/permissions/:target", getExistence)
 
 	return e
 }
@@ -59,6 +60,19 @@ func deletePermission(c *gin.Context) {
 	}
 
 	c.JSON(200, fmt.Sprintf("Successfully deleted permission Target '%s'", target))
+}
+
+func getExistence(c *gin.Context) {
+	target := c.Param("target")
+
+	switch target {
+	case "valid":
+		c.Status(200)
+		return
+	default:
+		c.Status(404)
+		return
+	}
 }
 
 func loadFixture(file string) string {

--- a/artifactory/permissionsv2.go
+++ b/artifactory/permissionsv2.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2016 John E. Vincent
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) 2018 Target Brands, Inc.
+
+package artifactory
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// PermissionsServiceV2 handles communication with the permissions related
+// methods of the Artifactory API v2.
+//
+// Docs: https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API+V2
+type PermissionsServiceV2 service
+
+// Exists validates if the specific permission target exists.
+//
+// Docs: https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API+V2#ArtifactoryRESTAPIV2-PermissionTargetexistencecheck
+func (s *PermissionsServiceV2) Exists(target string) (bool, error) {
+	u := fmt.Sprintf("/api/v2/security/permissions/%s", target)
+	resp, err := s.client.Call("HEAD", u, nil, nil)
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/artifactory/permissionsv2_test.go
+++ b/artifactory/permissionsv2_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2016 John E. Vincent
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) 2018 Target Brands, Inc.
+
+package artifactory
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/franela/goblin"
+	"github.com/gin-gonic/gin"
+	"github.com/target/go-arty/artifactory/fixtures/permissions"
+)
+
+func Test_PermissionsV2(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Create http test server from our fake API handler
+	s := httptest.NewServer(permissions.FakeHandler())
+
+	// Create the client to interact with the http test server
+	c, _ := NewClient(s.URL, nil)
+
+	g := goblin.Goblin(t)
+	g.Describe("PermissionsV2 Service", func() {
+		// Close http test server after we're done using it
+		g.After(func() {
+			s.Close()
+		})
+
+		g.Describe("PermissionsV2", func() {
+
+			g.It("- should return true for existing permission target", func() {
+				actual, err := c.PermissionsV2.Exists("valid")
+				g.Assert(actual).Equal(true)
+				g.Assert(err).Equal(nil)
+			})
+
+			g.It("- should return false for non existent permission target", func() {
+				actual, err := c.PermissionsV2.Exists("foo")
+				g.Assert(actual).Equal(false)
+				g.Assert(err).Equal(nil)
+			})
+		})
+	})
+}


### PR DESCRIPTION
This starts the initial work to add some [V2 endpoints](https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API+V2) that were added somewhat recently  to Artifactory.

@jbrockopp - as discussed earlier today on Slack.