### PR TITLE
Add replications service

### DIFF
--- a/artifactory/artifactory-accessors.go
+++ b/artifactory/artifactory-accessors.go
@@ -1655,6 +1655,14 @@ func (r *Replication) GetUsername() string {
 	return *r.Username
 }
 
+// GetReplicationType returns the ReplicationType field if it's non-nil, zero value otherwise.
+func (r *Replications) GetReplicationType() string {
+	if r == nil || r.ReplicationType == nil {
+		return ""
+	}
+	return *r.ReplicationType
+}
+
 // GetFilesCount returns the FilesCount field if it's non-nil, zero value otherwise.
 func (r *RepositoriesSummary) GetFilesCount() int {
 	if r == nil || r.FilesCount == nil {

--- a/artifactory/artifactory-accessors.go
+++ b/artifactory/artifactory-accessors.go
@@ -1167,6 +1167,30 @@ func (m *Modules) GetProperties() map[string]string {
 	return *m.Properties
 }
 
+// GetCronExp returns the CronExp field if it's non-nil, zero value otherwise.
+func (m *MultiPushReplication) GetCronExp() string {
+	if m == nil || m.CronExp == nil {
+		return ""
+	}
+	return *m.CronExp
+}
+
+// GetEnableEventReplication returns the EnableEventReplication field if it's non-nil, zero value otherwise.
+func (m *MultiPushReplication) GetEnableEventReplication() bool {
+	if m == nil || m.EnableEventReplication == nil {
+		return false
+	}
+	return *m.EnableEventReplication
+}
+
+// GetReplications returns the Replications field if it's non-nil, zero value otherwise.
+func (m *MultiPushReplication) GetReplications() []Replication {
+	if m == nil || m.Replications == nil {
+		return nil
+	}
+	return *m.Replications
+}
+
 // GetExcludesPattern returns the ExcludesPattern field if it's non-nil, zero value otherwise.
 func (p *PermissionTarget) GetExcludesPattern() string {
 	if p == nil || p.ExcludesPattern == nil {
@@ -1525,6 +1549,110 @@ func (r *RemoteRepository) GetXrayIndex() bool {
 		return false
 	}
 	return *r.XrayIndex
+}
+
+// GetCheckBinaryExistenceInFilestore returns the CheckBinaryExistenceInFilestore field if it's non-nil, zero value otherwise.
+func (r *Replication) GetCheckBinaryExistenceInFilestore() bool {
+	if r == nil || r.CheckBinaryExistenceInFilestore == nil {
+		return false
+	}
+	return *r.CheckBinaryExistenceInFilestore
+}
+
+// GetCronExp returns the CronExp field if it's non-nil, zero value otherwise.
+func (r *Replication) GetCronExp() string {
+	if r == nil || r.CronExp == nil {
+		return ""
+	}
+	return *r.CronExp
+}
+
+// GetEnabled returns the Enabled field if it's non-nil, zero value otherwise.
+func (r *Replication) GetEnabled() bool {
+	if r == nil || r.Enabled == nil {
+		return false
+	}
+	return *r.Enabled
+}
+
+// GetEnableEventReplication returns the EnableEventReplication field if it's non-nil, zero value otherwise.
+func (r *Replication) GetEnableEventReplication() bool {
+	if r == nil || r.EnableEventReplication == nil {
+		return false
+	}
+	return *r.EnableEventReplication
+}
+
+// GetPassword returns the Password field if it's non-nil, zero value otherwise.
+func (r *Replication) GetPassword() string {
+	if r == nil || r.Password == nil {
+		return ""
+	}
+	return *r.Password
+}
+
+// GetPathPrefix returns the PathPrefix field if it's non-nil, zero value otherwise.
+func (r *Replication) GetPathPrefix() string {
+	if r == nil || r.PathPrefix == nil {
+		return ""
+	}
+	return *r.PathPrefix
+}
+
+// GetRepoKey returns the RepoKey field if it's non-nil, zero value otherwise.
+func (r *Replication) GetRepoKey() string {
+	if r == nil || r.RepoKey == nil {
+		return ""
+	}
+	return *r.RepoKey
+}
+
+// GetSocketTimeoutMillis returns the SocketTimeoutMillis field if it's non-nil, zero value otherwise.
+func (r *Replication) GetSocketTimeoutMillis() int {
+	if r == nil || r.SocketTimeoutMillis == nil {
+		return 0
+	}
+	return *r.SocketTimeoutMillis
+}
+
+// GetSyncDeletes returns the SyncDeletes field if it's non-nil, zero value otherwise.
+func (r *Replication) GetSyncDeletes() bool {
+	if r == nil || r.SyncDeletes == nil {
+		return false
+	}
+	return *r.SyncDeletes
+}
+
+// GetSyncProperties returns the SyncProperties field if it's non-nil, zero value otherwise.
+func (r *Replication) GetSyncProperties() bool {
+	if r == nil || r.SyncProperties == nil {
+		return false
+	}
+	return *r.SyncProperties
+}
+
+// GetSyncStatistics returns the SyncStatistics field if it's non-nil, zero value otherwise.
+func (r *Replication) GetSyncStatistics() bool {
+	if r == nil || r.SyncStatistics == nil {
+		return false
+	}
+	return *r.SyncStatistics
+}
+
+// GetUrl returns the Url field if it's non-nil, zero value otherwise.
+func (r *Replication) GetUrl() string {
+	if r == nil || r.Url == nil {
+		return ""
+	}
+	return *r.Url
+}
+
+// GetUsername returns the Username field if it's non-nil, zero value otherwise.
+func (r *Replication) GetUsername() string {
+	if r == nil || r.Username == nil {
+		return ""
+	}
+	return *r.Username
 }
 
 // GetFilesCount returns the FilesCount field if it's non-nil, zero value otherwise.

--- a/artifactory/client.go
+++ b/artifactory/client.go
@@ -54,6 +54,7 @@ type Client struct {
 	Licenses       *LicensesService
 	Permissions    *PermissionsService
 	PermissionsV2  *PermissionsServiceV2
+	Replications   *ReplicationsService
 	Repositories   *RepositoriesService
 	Search         *SearchService
 	Storage        *StorageService
@@ -95,6 +96,7 @@ func NewClient(baseUrl string, httpClient *http.Client) (*Client, error) {
 	c.Licenses = &LicensesService{client: c}
 	c.Permissions = &PermissionsService{client: c}
 	c.PermissionsV2 = &PermissionsServiceV2{client: c}
+	c.Replications = &ReplicationsService{client: c}
 	c.Repositories = &RepositoriesService{client: c}
 	c.Search = &SearchService{client: c}
 	c.Storage = &StorageService{client: c}

--- a/artifactory/fixtures/replications/handler.go
+++ b/artifactory/fixtures/replications/handler.go
@@ -1,0 +1,101 @@
+package replications
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// FakeHandler returns an http.Handler that is capable of handling repository
+// related Artifactory API requests and returning mock responses.
+func FakeHandler() http.Handler {
+	gin.SetMode(gin.TestMode)
+
+	e := gin.New()
+
+	e.GET("/api/replications/:repository", getReplication)
+	e.DELETE("/api/replications/:repository", deleteReplication)
+	e.PUT("/api/replications/:repository", createReplication)
+	e.POST("/api/replications/:repository", updateReplication)
+	e.PUT("/api/replications/:repository/:multiRepository", createReplication)
+	e.POST("/api/replications/:repository/:multiRepository", updateReplication)
+
+	return e
+}
+
+func getReplication(c *gin.Context) {
+	repository := c.Param("repository")
+
+	if strings.Contains(repository, "not-found") {
+		c.JSON(404, fmt.Sprintf("Repository %s does not exist", repository))
+		return
+	}
+
+	if strings.Contains(repository, "local") {
+		c.String(200, loadFixture("fixtures/replications/local_replication.json"))
+		return
+	}
+
+	if strings.Contains(repository, "remote") {
+		c.String(200, loadFixture("fixtures/replications/remote_replication.json"))
+		return
+	}
+
+	c.JSON(404, fmt.Sprintf("Repository %s does not exist", repository))
+}
+
+func createReplication(c *gin.Context) {
+	repository := c.Param("multiRepository")
+	if repository == "" {
+		repository = c.Param("repository")
+	}
+	if strings.Contains(repository, "not-found") {
+		c.JSON(404, fmt.Sprintf("Repository %s does not exist", repository))
+		return
+	}
+
+	c.JSON(201, fmt.Sprintf("Successfully created replication for repository '%s'", repository))
+}
+
+func updateReplication(c *gin.Context) {
+	repository := c.Param("multiRepository")
+	if repository == "" {
+		repository = c.Param("repository")
+	}
+	if strings.Contains(repository, "not-found") {
+		c.JSON(404, fmt.Sprintf("Repository %s does not exist", repository))
+		return
+	}
+
+	c.JSON(200, fmt.Sprintf("Successfully updated replication for repository '%s'", repository))
+}
+
+func deleteReplication(c *gin.Context) {
+	repository := c.Param("repository")
+	url := c.Query("url")
+
+	if strings.Contains(repository, "not-found") {
+		c.JSON(404, fmt.Sprintf("Repository %s does not exist", repository))
+		return
+	}
+
+	if len(url) > 0 {
+		if strings.Contains(url, "http://host:port/target-repo") {
+			c.JSON(200, fmt.Sprintf("Successfully deleted replication url '%s' for repository '%s'", url, repository))
+			return
+		}
+
+		c.JSON(400, fmt.Sprintln("Invalid replication url"))
+	}
+
+	c.JSON(200, fmt.Sprintf("Successfully deleted replications for repository '%s'", repository))
+}
+
+func loadFixture(file string) string {
+	data, _ := ioutil.ReadFile(file)
+
+	return string(data)
+}

--- a/artifactory/fixtures/replications/handler.go
+++ b/artifactory/fixtures/replications/handler.go
@@ -16,6 +16,7 @@ func FakeHandler() http.Handler {
 
 	e := gin.New()
 
+	e.GET("/api/replications", getReplications)
 	e.GET("/api/replications/:repository", getReplication)
 	e.DELETE("/api/replications/:repository", deleteReplication)
 	e.PUT("/api/replications/:repository", createReplication)
@@ -24,6 +25,10 @@ func FakeHandler() http.Handler {
 	e.POST("/api/replications/:repository/:multiRepository", updateReplication)
 
 	return e
+}
+
+func getReplications(c *gin.Context) {
+	c.String(200, loadFixture("fixtures/replications/replications.json"))
 }
 
 func getReplication(c *gin.Context) {

--- a/artifactory/fixtures/replications/local_replication.json
+++ b/artifactory/fixtures/replications/local_replication.json
@@ -1,0 +1,18 @@
+[
+  {
+    "username" : "replication-user",
+    "password" : "pass",
+    "url" : "http://host:port/target-repo",
+    "socketTimeoutMillis" : 15000,
+    "cronExp" : "0 0 12 * * ?",
+    "repoKey" : "local-repo1",
+    "replicationKey" : "local-repo1_https10a1b2c3d4e",
+    "enableEventReplication" : true,
+    "enabled" : true,
+    "syncDeletes" : true,
+    "syncProperties" : true,
+    "syncStatistics" : false,
+    "pathPrefix" : "path/to/replicate",
+    "checkBinaryExistenceInFilestore" : false
+  }
+]

--- a/artifactory/fixtures/replications/remote_replication.json
+++ b/artifactory/fixtures/replications/remote_replication.json
@@ -1,0 +1,11 @@
+{
+  "enabled" : true,
+  "cronExp" : "0 0 12 * * ?",
+  "syncDeletes" : true,
+  "syncProperties" : true,
+  "pathPrefix" : "",
+  "repoKey" : "remote-repo1",
+  "replicationKey" : "remote-repo_",
+  "enableEventReplication" : true,
+  "checkBinaryExistenceInFilestore" : false
+}

--- a/artifactory/fixtures/replications/replications.json
+++ b/artifactory/fixtures/replications/replications.json
@@ -1,0 +1,26 @@
+[
+  {
+    "replicationType" : "PUSH",
+    "enabled" : true,
+    "cronExp" : "0 0 12 * * ?",
+    "syncDeletes" : true,
+    "syncProperties" : true,
+    "pathPrefix" : "path/to/replicate",
+    "repoKey" : "local-repo1",
+    "enableEventReplication" : true,
+    "checkBinaryExistenceInFilestore" : false,
+    "url" : "http://host:port/target-repo",
+    "syncStatistics" : false
+  },
+  {
+    "replicationType" : "PULL",
+    "enabled" : true,
+    "cronExp" : "0 0 12 * * ?",
+    "syncDeletes" : true,
+    "syncProperties" : true,
+    "repoKey" : "remote-repo1",
+    "enableEventReplication" : true,
+    "checkBinaryExistenceInFilestore" : false,
+    "syncStatistics" : false
+  }
+]

--- a/artifactory/replications.go
+++ b/artifactory/replications.go
@@ -1,0 +1,1 @@
+package artifactory

--- a/artifactory/replications.go
+++ b/artifactory/replications.go
@@ -1,1 +1,149 @@
 package artifactory
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+)
+
+// ReplicationsService handles communication with the replications related
+// methods of the Artifactory API.
+//
+// Docs: https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-GetRepositoryReplicationConfiguration
+type ReplicationsService service
+
+// Replication represents possible fields across all replication types in Artifactory.
+//
+// Docs: https://www.jfrog.com/confluence/display/RTF/Replication+Configuration+JSON
+type Replication struct {
+	Username *string `json:"username,omitempty"`
+	Password *string `json:"password,omitempty"`
+	Url *string `json:"url,omitempty"`
+	SocketTimeoutMillis *int `json:"socketTimeoutMillis,omitempty"`
+	CronExp *string `json:"cronExp,omitempty"`
+	RepoKey *string `json:"repoKey,omitempty"`
+	EnableEventReplication *bool `json:"enableEventReplication,omitempty"`
+	Enabled *bool `json:"enabled,omitempty"`
+	SyncDeletes *bool `json:"syncDeletes,omitempty"`
+	SyncProperties *bool `json:"syncProperties,omitempty"`
+	SyncStatistics *bool `json:"syncStatistics,omitempty"`
+	PathPrefix *string `json:"pathPrefix,omitempty"`
+	CheckBinaryExistenceInFilestore *bool `json:"checkBinaryExistenceInFilestore,omitempty"`
+}
+
+func (r Replication) String() string {
+	return Stringify(r)
+}
+
+// MultiPushReplication represents a Local Multi-push replication in Artifactory
+type MultiPushReplication struct {
+	CronExp *string `json:"cronExp,omitempty"`
+	EnableEventReplication *bool `json:"enableEventReplication,omitempty"`
+	Replications *[]Replication `json:"replications,omitempty"`
+}
+
+func (r MultiPushReplication) String() string {
+	return Stringify(r)
+}
+
+// Get returns replications for the provided repository.
+// Artifactory returns a JSON array for a local replication or a JSON object for a remote replication.
+// This method returns a slice to maintain consistency.
+// Docs: https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-GetRepositoryReplicationConfiguration
+func (r *ReplicationsService) Get(repo string) (*[]Replication, *Response, error) {
+	u := fmt.Sprintf("/api/replications/%s", repo)
+	v := new(bytes.Buffer)
+
+	replications := new([]Replication)
+
+	resp, err := r.client.Call("GET", u, nil, v)
+	if err != nil {
+		if resp.StatusCode == 404 {
+			return replications, resp, err
+		}
+		return nil, resp, err
+	}
+
+	body, err := ioutil.ReadAll(v)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	switch body[0] {
+	case '[':
+		err = json.Unmarshal(body, replications)
+	case '{':
+		replication := new(Replication)
+		if err = json.Unmarshal(body, replication); err == nil {
+			replications = &[]Replication{*replication}
+		}
+	}
+	return replications, resp, err
+}
+
+// Create constructs a single replication for the provided repository.
+// If multiple push replications are required CreateMultiPush needs to be used
+// Docs: https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-CreateRepository
+func (r *ReplicationsService) Create(repo string, replication *Replication) (*string, *Response, error) {
+	u := fmt.Sprintf("/api/replications/%s", repo)
+	v := new(string)
+
+	resp, err := r.client.Call("PUT", u, replication, v)
+	return v, resp, err
+}
+
+// Update updates a single replication for the provided repository. If updates are required
+// for a local repository with multiple push replications UpdateMultiPush needs to be used
+// Docs: https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-UpdateRepositoryReplicationConfiguration
+func (r *ReplicationsService) Update(repo string, replication *Replication) (*string, *Response, error) {
+	u := fmt.Sprintf("/api/replications/%s", repo)
+	v := new(string)
+
+	resp, err := r.client.Call("POST", u, replication, v)
+	return v, resp, err
+}
+
+// Delete deletes the existing replication configuration for the provided repository.
+//
+// Docs: https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-DeleteRepositoryReplicationConfiguration
+func (r *ReplicationsService) Delete(repo string) (*string, *Response, error) {
+	u := fmt.Sprintf("/api/replications/%s", repo)
+	v := new(string)
+
+	resp, err := r.client.Call("DELETE", u, nil, v)
+	return v, resp, err
+}
+
+// CreateMultiPush constructs a Local Multi-push replication for the provided repository.
+//
+// Docs: https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-CreateorReplaceLocalMulti-pushReplication
+func (r *ReplicationsService) CreateMultiPush(repo string, replications *MultiPushReplication) (*string, *Response, error) {
+	u := fmt.Sprintf("/api/replications/multiple/%s", repo)
+	v := new(string)
+
+	resp, err := r.client.Call("PUT", u, replications, v)
+	return v, resp, err
+}
+
+// UpdateMultiPush updates a Local Multi-push replication for the provided repository
+//
+// Docs: https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-UpdateLocalMulti-pushReplication
+func (r *ReplicationsService) UpdateMultiPush(repo string, replications *MultiPushReplication) (*string, *Response, error) {
+	u := fmt.Sprintf("/api/replications/multiple/%s", repo)
+	v := new(string)
+
+	resp, err := r.client.Call("POST", u, replications, v)
+	return v, resp, err
+}
+
+// DeleteMultiPush deletes replication configuration at the provided URL for the provided repository.
+//
+// Docs: https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-DeleteRepositoryReplicationConfiguration
+func (r *ReplicationsService) DeleteMultiPush(repo string, url string) (*string, *Response, error) {
+	u := fmt.Sprintf("/api/replications/%s?url=%s", repo, url)
+	v := new(string)
+
+	resp, err := r.client.Call("DELETE", u, nil, v)
+	return v, resp, err
+}

--- a/artifactory/replications.go
+++ b/artifactory/replications.go
@@ -63,7 +63,7 @@ func (r MultiPushReplication) String() string {
 //
 // Docs: This endpoint is currently undocumented by JFrog
 func (r *ReplicationsService) GetAll() (*[]Replications, *Response, error) {
-	u := fmt.Sprintf("api/replications")
+	u := fmt.Sprintf("/api/replications")
 	v := new([]Replications)
 
 	resp, err := r.client.Call("GET", u, nil, v)

--- a/artifactory/replications.go
+++ b/artifactory/replications.go
@@ -39,7 +39,6 @@ func (r Replication) String() string {
 // Replications represents a replication returned by the undocumented replications endpoint.
 //
 // Docs: This struct is currently undocumented by JFrog
-
 type Replications struct {
 	*Replication
 	ReplicationType *string `json:"replicationType,omitempty"`

--- a/artifactory/replications.go
+++ b/artifactory/replications.go
@@ -36,6 +36,19 @@ func (r Replication) String() string {
 	return Stringify(r)
 }
 
+// Replications represents a replication returned by the undocumented replications endpoint.
+//
+// Docs: This struct is currently undocumented by JFrog
+
+type Replications struct {
+	*Replication
+	ReplicationType *string `json:"replicationType,omitempty"`
+}
+
+func (r Replications) String() string {
+	return Stringify(r)
+}
+
 // MultiPushReplication represents a Local Multi-push replication in Artifactory
 type MultiPushReplication struct {
 	CronExp                *string        `json:"cronExp,omitempty"`
@@ -45,6 +58,17 @@ type MultiPushReplication struct {
 
 func (r MultiPushReplication) String() string {
 	return Stringify(r)
+}
+
+// GetAll returns a list of all replications.
+//
+// Docs: This endpoint is currently undocumented by JFrog
+func (r *ReplicationsService) GetAll() (*[]Replications, *Response, error) {
+	u := fmt.Sprintf("api/replications")
+	v := new([]Replications)
+
+	resp, err := r.client.Call("GET", u, nil, v)
+	return v, resp, err
 }
 
 // Get returns replications for the provided repository.

--- a/artifactory/replications.go
+++ b/artifactory/replications.go
@@ -17,19 +17,19 @@ type ReplicationsService service
 //
 // Docs: https://www.jfrog.com/confluence/display/RTF/Replication+Configuration+JSON
 type Replication struct {
-	Username *string `json:"username,omitempty"`
-	Password *string `json:"password,omitempty"`
-	Url *string `json:"url,omitempty"`
-	SocketTimeoutMillis *int `json:"socketTimeoutMillis,omitempty"`
-	CronExp *string `json:"cronExp,omitempty"`
-	RepoKey *string `json:"repoKey,omitempty"`
-	EnableEventReplication *bool `json:"enableEventReplication,omitempty"`
-	Enabled *bool `json:"enabled,omitempty"`
-	SyncDeletes *bool `json:"syncDeletes,omitempty"`
-	SyncProperties *bool `json:"syncProperties,omitempty"`
-	SyncStatistics *bool `json:"syncStatistics,omitempty"`
-	PathPrefix *string `json:"pathPrefix,omitempty"`
-	CheckBinaryExistenceInFilestore *bool `json:"checkBinaryExistenceInFilestore,omitempty"`
+	Username                        *string `json:"username,omitempty"`
+	Password                        *string `json:"password,omitempty"`
+	Url                             *string `json:"url,omitempty"`
+	SocketTimeoutMillis             *int    `json:"socketTimeoutMillis,omitempty"`
+	CronExp                         *string `json:"cronExp,omitempty"`
+	RepoKey                         *string `json:"repoKey,omitempty"`
+	EnableEventReplication          *bool   `json:"enableEventReplication,omitempty"`
+	Enabled                         *bool   `json:"enabled,omitempty"`
+	SyncDeletes                     *bool   `json:"syncDeletes,omitempty"`
+	SyncProperties                  *bool   `json:"syncProperties,omitempty"`
+	SyncStatistics                  *bool   `json:"syncStatistics,omitempty"`
+	PathPrefix                      *string `json:"pathPrefix,omitempty"`
+	CheckBinaryExistenceInFilestore *bool   `json:"checkBinaryExistenceInFilestore,omitempty"`
 }
 
 func (r Replication) String() string {
@@ -38,9 +38,9 @@ func (r Replication) String() string {
 
 // MultiPushReplication represents a Local Multi-push replication in Artifactory
 type MultiPushReplication struct {
-	CronExp *string `json:"cronExp,omitempty"`
-	EnableEventReplication *bool `json:"enableEventReplication,omitempty"`
-	Replications *[]Replication `json:"replications,omitempty"`
+	CronExp                *string        `json:"cronExp,omitempty"`
+	EnableEventReplication *bool          `json:"enableEventReplication,omitempty"`
+	Replications           *[]Replication `json:"replications,omitempty"`
 }
 
 func (r MultiPushReplication) String() string {

--- a/artifactory/replications_test.go
+++ b/artifactory/replications_test.go
@@ -1,0 +1,1 @@
+package artifactory

--- a/artifactory/replications_test.go
+++ b/artifactory/replications_test.go
@@ -44,6 +44,22 @@ func Test_Replications(t *testing.T) {
 				CheckBinaryExistenceInFilestore: Bool(false),
 			}
 
+			replications := &Replications{
+				ReplicationType: String("PUSH"),
+				Replication: &Replication{
+					Enabled:                         Bool(true),
+					CronExp:                         String("0 0 12 * * ?"),
+					SyncDeletes:                     Bool(true),
+					SyncProperties:                  Bool(true),
+					PathPrefix:                      String("path/to/replicate"),
+					RepoKey:                         String("local-repo1"),
+					EnableEventReplication:          Bool(true),
+					CheckBinaryExistenceInFilestore: Bool(false),
+					Url:                             String("http://host:port/target-repo"),
+					SyncStatistics:                  Bool(false),
+				},
+			}
+
 			localReplication := &Replication{
 				Username:                        String("replication-user"),
 				Password:                        String("pass"),
@@ -80,6 +96,19 @@ func Test_Replications(t *testing.T) {
 				},
 			}
 
+			g.It("- should return valid string for replications with String()", func() {
+				actual := []Replications{
+					*replications,
+				}
+
+				data, _ := ioutil.ReadFile("fixtures/replications/replications.json")
+
+				var expected []Replications
+				_ = json.Unmarshal(data, &expected)
+
+				g.Assert(actual[0].String() == expected[0].String()).IsTrue()
+			})
+
 			g.It("- should return valid string for Local (push) replication with String()", func() {
 				actual := []Replication{
 					*localReplication,
@@ -102,6 +131,13 @@ func Test_Replications(t *testing.T) {
 				_ = json.Unmarshal(data, &expected)
 
 				g.Assert(actual.String() == expected.String()).IsTrue()
+			})
+
+			g.It("- should return no error with GetAll()", func() {
+				actual, resp, err := c.Replications.GetAll()
+				g.Assert(actual != nil).IsTrue()
+				g.Assert(resp != nil).IsTrue()
+				g.Assert(err == nil).IsTrue()
 			})
 
 			g.It("- should return no error with Get() on local replication", func() {

--- a/artifactory/replications_test.go
+++ b/artifactory/replications_test.go
@@ -62,7 +62,7 @@ func Test_Replications(t *testing.T) {
 
 			remoteReplication := &Replication{
 				Enabled:                         Bool(true),
-				CronExp:                         String("0 0 12 * * ?", ),
+				CronExp:                         String("0 0 12 * * ?"),
 				SyncDeletes:                     Bool(true),
 				SyncProperties:                  Bool(true),
 				PathPrefix:                      String(""),
@@ -74,7 +74,7 @@ func Test_Replications(t *testing.T) {
 			multiPushReplication := &MultiPushReplication{
 				CronExp:                String("0 0 12 * * ?"),
 				EnableEventReplication: Bool(true),
-				Replications:           &[]Replication{
+				Replications: &[]Replication{
 					*localReplication,
 					*replication,
 				},

--- a/artifactory/replications_test.go
+++ b/artifactory/replications_test.go
@@ -1,1 +1,178 @@
 package artifactory
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/franela/goblin"
+	"github.com/gin-gonic/gin"
+	"github.com/target/go-arty/artifactory/fixtures/replications"
+)
+
+func Test_Replications(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Create http test server from our fake API handler
+	s := httptest.NewServer(replications.FakeHandler())
+
+	// Create the client to interact with the http test server
+	c, _ := NewClient(s.URL, nil)
+
+	g := goblin.Goblin(t)
+	g.Describe("Replications Service", func() {
+		// Close http test server after we're done using it
+		g.After(func() {
+			s.Close()
+		})
+
+		g.Describe("Replication", func() {
+			replication := &Replication{
+				Username:                        String("replication-user"),
+				Password:                        String("pass"),
+				Url:                             String("http://host:port/some-repo"),
+				SocketTimeoutMillis:             Int(15000),
+				CronExp:                         String("0 0 12 * * ?"),
+				RepoKey:                         String("test"),
+				EnableEventReplication:          Bool(true),
+				Enabled:                         Bool(true),
+				SyncDeletes:                     Bool(true),
+				SyncProperties:                  Bool(true),
+				SyncStatistics:                  Bool(true),
+				PathPrefix:                      String("path/to/replicate"),
+				CheckBinaryExistenceInFilestore: Bool(false),
+			}
+
+			localReplication := &Replication{
+				Username:                        String("replication-user"),
+				Password:                        String("pass"),
+				Url:                             String("http://host:port/target-repo"),
+				SocketTimeoutMillis:             Int(15000),
+				CronExp:                         String("0 0 12 * * ?"),
+				RepoKey:                         String("local-repo1"),
+				EnableEventReplication:          Bool(true),
+				Enabled:                         Bool(true),
+				SyncDeletes:                     Bool(true),
+				SyncProperties:                  Bool(true),
+				SyncStatistics:                  Bool(false),
+				PathPrefix:                      String("path/to/replicate"),
+				CheckBinaryExistenceInFilestore: Bool(false),
+			}
+
+			remoteReplication := &Replication{
+				Enabled:                         Bool(true),
+				CronExp:                         String("0 0 12 * * ?", ),
+				SyncDeletes:                     Bool(true),
+				SyncProperties:                  Bool(true),
+				PathPrefix:                      String(""),
+				RepoKey:                         String("remote-repo1"),
+				EnableEventReplication:          Bool(true),
+				CheckBinaryExistenceInFilestore: Bool(false),
+			}
+
+			multiPushReplication := &MultiPushReplication{
+				CronExp:                String("0 0 12 * * ?"),
+				EnableEventReplication: Bool(true),
+				Replications:           &[]Replication{
+					*localReplication,
+					*replication,
+				},
+			}
+
+			g.It("- should return valid string for Local (push) replication with String()", func() {
+				actual := []Replication{
+					*localReplication,
+				}
+
+				data, _ := ioutil.ReadFile("fixtures/replications/local_replication.json")
+
+				var expected []Replication
+				_ = json.Unmarshal(data, &expected)
+
+				g.Assert(actual[0].String() == expected[0].String()).IsTrue()
+			})
+
+			g.It("- should return valid string for Remote (pull) replication with String()", func() {
+				actual := remoteReplication
+
+				data, _ := ioutil.ReadFile("fixtures/replications/remote_replication.json")
+
+				var expected Replication
+				_ = json.Unmarshal(data, &expected)
+
+				g.Assert(actual.String() == expected.String()).IsTrue()
+			})
+
+			g.It("- should return no error with Get() on local replication", func() {
+				actual, resp, err := c.Replications.Get("local-repo1")
+				g.Assert(actual != nil).IsTrue()
+				g.Assert(resp != nil).IsTrue()
+				g.Assert(err == nil).IsTrue()
+			})
+
+			g.It("- should return no error with Get() on remote replication", func() {
+				actual, resp, err := c.Replications.Get("remote-repo1")
+				g.Assert(actual != nil).IsTrue()
+				g.Assert(resp != nil).IsTrue()
+				if err != nil {
+					g.Fail(err.Error())
+				}
+			})
+
+			g.It("- should return no error with Create()", func() {
+				actual, resp, err := c.Replications.Create("test", replication)
+				g.Assert(actual != nil).IsTrue()
+				g.Assert(resp != nil).IsTrue()
+				if err != nil {
+					g.Fail(err.Error())
+				}
+			})
+
+			g.It("- should return no error with Update()", func() {
+				actual, resp, err := c.Replications.Update("test", replication)
+				g.Assert(actual != nil).IsTrue()
+				g.Assert(resp != nil).IsTrue()
+				if err != nil {
+					g.Fail(err.Error())
+				}
+			})
+
+			g.It("- should return no error with Delete()", func() {
+				actual, resp, err := c.Replications.Delete("test")
+				g.Assert(actual != nil).IsTrue()
+				g.Assert(resp != nil).IsTrue()
+				if err != nil {
+					g.Fail(err.Error())
+				}
+			})
+
+			g.It("- should return no error with CreateMultiPush()", func() {
+				actual, resp, err := c.Replications.CreateMultiPush("test", multiPushReplication)
+				g.Assert(actual != nil).IsTrue()
+				g.Assert(resp != nil).IsTrue()
+				if err != nil {
+					g.Fail(err.Error())
+				}
+			})
+
+			g.It("- should return no error with UpdateMultiPush()", func() {
+				actual, resp, err := c.Replications.UpdateMultiPush("test", multiPushReplication)
+				g.Assert(actual != nil).IsTrue()
+				g.Assert(resp != nil).IsTrue()
+				if err != nil {
+					g.Fail(err.Error())
+				}
+			})
+
+			g.It("- should return no error with DeleteMultiPush()", func() {
+				actual, resp, err := c.Replications.DeleteMultiPush("test", "http://host:port/target-repo")
+				g.Assert(actual != nil).IsTrue()
+				g.Assert(resp != nil).IsTrue()
+				if err != nil {
+					g.Fail(err.Error())
+				}
+			})
+		})
+	})
+}


### PR DESCRIPTION
Closes #39.

Adds the following functionality:

- create/update/delete single local and remote replications
- create/update/delete multi-push replication

Things to note/for discussion:

- Artifactory REST API Get method returns a JSON array for a local replication or a JSON object for a remote replication. This implementation returns a slice for both in order to maintain consistency.
- Undocumented replications REST API endpoint, which I've added a GetAll() method for.