### PR TITLE
fix(artifact upload): only utilize file for local usage

### DIFF
--- a/artifactory/artifacts.go
+++ b/artifactory/artifacts.go
@@ -77,7 +77,7 @@ func (s *ArtifactsService) Upload(repo, path, file string, properties map[string
 		}
 	}
 
-	u := fmt.Sprintf("/%s/%s/%s;%s", repo, path, file, propertyString)
+	u := fmt.Sprintf("/%s/%s;%s", repo, path, propertyString)
 	v := new(string)
 
 	data, err := os.Open(file)

--- a/artifactory/artifacts.go
+++ b/artifactory/artifacts.go
@@ -61,7 +61,7 @@ func (s *ArtifactsService) Download(repo, path string) (*[]byte, *Response, erro
 // Upload deploys the provided artifact to the provided repository.
 //
 // Docs: https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-DeployArtifact
-func (s *ArtifactsService) Upload(repo, path, file string, properties map[string][]string) (*string, *Response, error) {
+func (s *ArtifactsService) Upload(repo, path, source string, properties map[string][]string) (*string, *Response, error) {
 	var propertyString string
 	var index int
 	for k, v := range properties {
@@ -80,7 +80,7 @@ func (s *ArtifactsService) Upload(repo, path, file string, properties map[string
 	u := fmt.Sprintf("/%s/%s;%s", repo, path, propertyString)
 	v := new(string)
 
-	data, err := os.Open(file)
+	data, err := os.Open(source)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/artifactory/artifacts_test.go
+++ b/artifactory/artifacts_test.go
@@ -88,7 +88,7 @@ func Test_Artifacts(t *testing.T) {
 			})
 
 			g.It("- should return no error with Upload() using 1 property", func() {
-				actual, resp, err := c.Artifacts.Upload("local-repo1", "folder", "fixtures/artifacts/foo.txt", map[string][]string{"key": []string{"value"}})
+				actual, resp, err := c.Artifacts.Upload("local-repo1", "folder/fixtures/artifacts/foo.txt", "fixtures/artifacts/foo.txt", map[string][]string{"key": []string{"value"}})
 				g.Assert(actual != nil).IsTrue()
 				g.Assert(resp != nil).IsTrue()
 				g.Assert(resp.Request.URL.Path).Equal("/local-repo1/folder/fixtures/artifacts/foo.txt;key=value")
@@ -105,7 +105,7 @@ func Test_Artifacts(t *testing.T) {
 			})
 
 			g.It("- should return no error with Upload() using multiple properties", func() {
-				actual, resp, err := c.Artifacts.Upload("local-repo1", "folder", "fixtures/artifacts/foo.txt", map[string][]string{"key": []string{"value", "value2", "value3"}})
+				actual, resp, err := c.Artifacts.Upload("local-repo1", "folder/fixtures/artifacts/foo.txt", "fixtures/artifacts/foo.txt", map[string][]string{"key": []string{"value", "value2", "value3"}})
 				g.Assert(actual != nil).IsTrue()
 				g.Assert(resp != nil).IsTrue()
 				g.Assert(resp.Request.URL.Path).Equal("/local-repo1/folder/fixtures/artifacts/foo.txt;key=value,value2,value3")
@@ -113,7 +113,7 @@ func Test_Artifacts(t *testing.T) {
 			})
 
 			g.It("- should return no error with Upload() using multiple property keys", func() {
-				actual, resp, err := c.Artifacts.Upload("local-repo1", "folder", "fixtures/artifacts/foo.txt", map[string][]string{"key": []string{"value", "value2", "value3"}, "key2": []string{"anothervalue"}})
+				actual, resp, err := c.Artifacts.Upload("local-repo1", "folder/fixtures/artifacts/foo.txt", "fixtures/artifacts/foo.txt", map[string][]string{"key": []string{"value", "value2", "value3"}, "key2": []string{"anothervalue"}})
 				g.Assert(actual != nil).IsTrue()
 				g.Assert(resp != nil).IsTrue()
 				g.Assert(strings.Contains(resp.Request.URL.Path, "key=value,value2,value3")).IsTrue()


### PR DESCRIPTION
This is a breaking change that will improve usage of the `Upload` function when you want different local file path compared to file path within Artifactory. For example, purpose you want to upload the local file located within `/usr/local/bin/foo`, but only want the path within Artifactory to be `<repo name>/foo` this change allows that.