### PR TITLE
add Group service GetIncludeUsers method

### DIFF
--- a/artifactory/artifactory-accessors.go
+++ b/artifactory/artifactory-accessors.go
@@ -847,6 +847,14 @@ func (g *Group) GetURI() string {
 	return *g.URI
 }
 
+// GetUserNames returns the UserNames field if it's non-nil, zero value otherwise.
+func (g *Group) GetUserNames() []string {
+	if g == nil || g.UserNames == nil {
+		return nil
+	}
+	return *g.UserNames
+}
+
 // GetExpired returns the Expired field if it's non-nil, zero value otherwise.
 func (h *HALicense) GetExpired() bool {
 	if h == nil || h.Expired == nil {

--- a/artifactory/fixtures/groups/group.json
+++ b/artifactory/fixtures/groups/group.json
@@ -1,8 +1,9 @@
 {
   "name": "dev-leads",
-  "description" : "The development leads group",
-  "autoJoin" : false,
-  "adminPrivileges" : false,
+  "description": "The development leads group",
+  "autoJoin": false,
+  "adminPrivileges": false,
   "realm": "ldap",
-  "realmAttributes": "Realm attributes for use by LDAP"
+  "realmAttributes": "Realm attributes for use by LDAP",
+  "userNames": [ "user1", "user2", "user3" ]
 }

--- a/artifactory/groups.go
+++ b/artifactory/groups.go
@@ -30,13 +30,14 @@ type GroupsService service
 //
 // Doc: https://www.jfrog.com/confluence/display/RTF/Security+Configuration+JSON#SecurityConfigurationJSON-application/vnd.org.jfrog.artifactory.security.Group+json
 type Group struct {
-	Name            *string `json:"name,omitempty"`
-	URI             *string `json:"uri,omitempty"`
-	Description     *string `json:"description,omitempty"`
-	AutoJoin        *bool   `json:"autoJoin,omitempty"`
-	AdminPrivileges *bool   `json:"adminPrivileges,omitempty"`
-	Realm           *string `json:"realm,omitempty"`
-	RealmAttributes *string `json:"realmAttributes,omitempty"`
+	Name            *string   `json:"name,omitempty"`
+	URI             *string   `json:"uri,omitempty"`
+	Description     *string   `json:"description,omitempty"`
+	AutoJoin        *bool     `json:"autoJoin,omitempty"`
+	AdminPrivileges *bool     `json:"adminPrivileges,omitempty"`
+	Realm           *string   `json:"realm,omitempty"`
+	RealmAttributes *string   `json:"realmAttributes,omitempty"`
+	UserNames       *[]string `json:"userNames,omitempty"`
 }
 
 func (g Group) String() string {
@@ -59,6 +60,17 @@ func (s *GroupsService) GetAll() (*[]Group, *Response, error) {
 // Docs: https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-GetGroupDetails
 func (s *GroupsService) Get(group string) (*Group, *Response, error) {
 	u := fmt.Sprintf("/api/security/groups/%s", group)
+	v := new(Group)
+
+	resp, err := s.client.Call("GET", u, nil, v)
+	return v, resp, err
+}
+
+// GetIncludeUsers returns the provided group including its user membership (Artifactory >= 6.13)
+//
+// Docs: https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-GetGroupDetails
+func (s *GroupsService) GetIncludeUsers(group string) (*Group, *Response, error) {
+	u := fmt.Sprintf("/api/security/groups/%s?includeUsers=true", group)
 	v := new(Group)
 
 	resp, err := s.client.Call("GET", u, nil, v)

--- a/artifactory/groups_test.go
+++ b/artifactory/groups_test.go
@@ -54,6 +54,7 @@ func Test_Groups(t *testing.T) {
 					AdminPrivileges: Bool(false),
 					Realm:           String("ldap"),
 					RealmAttributes: String("Realm attributes for use by LDAP"),
+					UserNames:       &[]string{"user1", "user2", "user3"},
 				}
 			})
 
@@ -75,6 +76,13 @@ func Test_Groups(t *testing.T) {
 
 			g.It("- should return no error with Get()", func() {
 				actual, resp, err := c.Groups.Get("dev-leads")
+				g.Assert(actual != nil).IsTrue()
+				g.Assert(resp != nil).IsTrue()
+				g.Assert(err == nil).IsTrue()
+			})
+
+			g.It("- should return no error with GetIncludeUsers()", func() {
+				actual, resp, err := c.Groups.GetIncludeUsers("dev-leads")
 				g.Assert(actual != nil).IsTrue()
 				g.Assert(resp != nil).IsTrue()
 				g.Assert(err == nil).IsTrue()


### PR DESCRIPTION
Adds a GetIncludeUsers method to Groups service which uses the includeUsers=true query param to include userNames field in the response (supported in Artifactory 6.13 onwards).

Closes #54 