### PR TITLE
add new fields to repository structs

### DIFF
--- a/artifactory/artifactory-accessors.go
+++ b/artifactory/artifactory-accessors.go
@@ -703,6 +703,14 @@ func (g *GenericRepository) GetExcludesPattern() string {
 	return *g.ExcludesPattern
 }
 
+// GetForceNugetAuthentication returns the ForceNugetAuthentication field if it's non-nil, zero value otherwise.
+func (g *GenericRepository) GetForceNugetAuthentication() bool {
+	if g == nil || g.ForceNugetAuthentication == nil {
+		return false
+	}
+	return *g.ForceNugetAuthentication
+}
+
 // GetHandleReleases returns the HandleReleases field if it's non-nil, zero value otherwise.
 func (g *GenericRepository) GetHandleReleases() bool {
 	if g == nil || g.HandleReleases == nil {
@@ -1527,6 +1535,14 @@ func (r *RemoteRepository) GetPassword() string {
 	return *r.Password
 }
 
+// GetPropagateQueryParams returns the PropagateQueryParams field if it's non-nil, zero value otherwise.
+func (r *RemoteRepository) GetPropagateQueryParams() bool {
+	if r == nil || r.PropagateQueryParams == nil {
+		return false
+	}
+	return *r.PropagateQueryParams
+}
+
 // GetProxy returns the Proxy field if it's non-nil, zero value otherwise.
 func (r *RemoteRepository) GetProxy() string {
 	if r == nil || r.Proxy == nil {
@@ -1541,6 +1557,22 @@ func (r *RemoteRepository) GetPyPIRegistryURL() string {
 		return ""
 	}
 	return *r.PyPIRegistryURL
+}
+
+// GetPyPIRepositorySuffix returns the PyPIRepositorySuffix field if it's non-nil, zero value otherwise.
+func (r *RemoteRepository) GetPyPIRepositorySuffix() string {
+	if r == nil || r.PyPIRepositorySuffix == nil {
+		return ""
+	}
+	return *r.PyPIRepositorySuffix
+}
+
+// GetQueryParams returns the QueryParams field if it's non-nil, zero value otherwise.
+func (r *RemoteRepository) GetQueryParams() string {
+	if r == nil || r.QueryParams == nil {
+		return ""
+	}
+	return *r.QueryParams
 }
 
 // GetRemoteRepoChecksumPolicyType returns the RemoteRepoChecksumPolicyType field if it's non-nil, zero value otherwise.
@@ -2207,6 +2239,14 @@ func (v *VirtualRepository) GetArtifactoryRequestsCanRetrieveRemoteArtifacts() b
 	return *v.ArtifactoryRequestsCanRetrieveRemoteArtifacts
 }
 
+// GetDebianDefaultArchitectures returns the DebianDefaultArchitectures field if it's non-nil, zero value otherwise.
+func (v *VirtualRepository) GetDebianDefaultArchitectures() string {
+	if v == nil || v.DebianDefaultArchitectures == nil {
+		return ""
+	}
+	return *v.DebianDefaultArchitectures
+}
+
 // GetDebianTrivialLayout returns the DebianTrivialLayout field if it's non-nil, zero value otherwise.
 func (v *VirtualRepository) GetDebianTrivialLayout() bool {
 	if v == nil || v.DebianTrivialLayout == nil {
@@ -2285,4 +2325,12 @@ func (v *VirtualRepository) GetResolveDockerTagsByTimestamp() bool {
 		return false
 	}
 	return *v.ResolveDockerTagsByTimestamp
+}
+
+// GetVirtualRetrievalCachePeriodSecs returns the VirtualRetrievalCachePeriodSecs field if it's non-nil, zero value otherwise.
+func (v *VirtualRepository) GetVirtualRetrievalCachePeriodSecs() int {
+	if v == nil || v.VirtualRetrievalCachePeriodSecs == nil {
+		return 0
+	}
+	return *v.VirtualRetrievalCachePeriodSecs
 }

--- a/artifactory/fixtures/repositories/generic_repository.json
+++ b/artifactory/fixtures/repositories/generic_repository.json
@@ -12,5 +12,7 @@
   "maxUniqueSnapshots" : 0,
   "suppressPomConsistencyChecks" : true,
   "blackedOut" : false,
-  "propertySets" : [ "artifactory" ]
+  "propertySets" : [ "artifactory" ],
+  "blockPushingSchema1" : true,
+  "forceNugetAuthentication" : false
 }

--- a/artifactory/fixtures/repositories/local_repository.json
+++ b/artifactory/fixtures/repositories/local_repository.json
@@ -25,5 +25,6 @@
   "enableFileListsIndexing" : "false",
   "optionalIndexCompressionFormats" : ["bz2", "lzma", "xz"],
   "xrayIndex" : false,
-  "downloadRedirect" : false
+  "downloadRedirect" : false,
+  "forceNugetAuthentication" : false
 }

--- a/artifactory/fixtures/repositories/remote_repository.json
+++ b/artifactory/fixtures/repositories/remote_repository.json
@@ -39,6 +39,7 @@
   "bowerRegistryUrl": "https://registry.bower.io",
   "composerRegistryUrl": "https://packagist.org",
   "pyPIRegistryUrl": "https://pypi.org",
+  "pyPIRepositorySuffix" : "simple",
   "vcsType": "GIT",
   "vcsGitProvider": "CUSTOM",
   "vcsGitDownloadUrl": "",
@@ -65,5 +66,8 @@
       "originAbsenceDetection" : true
     }
   },
-  "blockPushingSchema1" : true
+  "blockPushingSchema1" : true,
+  "forceNugetAuthentication" : false,
+  "queryParams" : "param1=val1",
+  "propagateQueryParams" : true
 }

--- a/artifactory/fixtures/repositories/virtual_repository.json
+++ b/artifactory/fixtures/repositories/virtual_repository.json
@@ -16,5 +16,9 @@
   "externalDependenciesEnabled": false,
   "externalDependenciesPatterns": ["**/*microsoft*/**", "**/*github*/**"],
   "externalDependenciesRemoteRepo": "",
-  "resolveDockerTagsByTimestamp": false
+  "resolveDockerTagsByTimestamp": false,
+  "blockPushingSchema1": true,
+  "forceNugetAuthentication": false,
+  "virtualRetrievalCachePeriodSecs": 600,
+  "debianDefaultArchitectures": "i386,amd64"
 }

--- a/artifactory/repositories.go
+++ b/artifactory/repositories.go
@@ -59,6 +59,7 @@ type GenericRepository struct {
 	SuppressPomConsistencyChecks *bool     `json:"suppressPomConsistencyChecks,omitempty"`
 	BlackedOut                   *bool     `json:"blackedOut,omitempty"`
 	PropertySets                 *[]string `json:"propertySets,omitempty"`
+	ForceNugetAuthentication     *bool     `json:"forceNugetAuthentication,omitempty"`
 }
 
 func (g GenericRepository) String() string {
@@ -122,6 +123,7 @@ type RemoteRepository struct {
 	BowerRegistryURL                  *string                 `json:"bowerRegistryUrl,omitempty"`
 	ComposerRegistryURL               *string                 `json:"composerRegistryUrl,omitempty"`
 	PyPIRegistryURL                   *string                 `json:"pyPIRegistryUrl,omitempty"`
+	PyPIRepositorySuffix              *string                 `json:"pyPIRepositorySuffix,omitempty"`
 	VcsType                           *string                 `json:"vcsType,omitempty"`
 	VcsGitProvider                    *string                 `json:"vcsGitProvider,omitempty"`
 	VcsGitDownloadUrl                 *string                 `json:"VcsGitDownloadUrl,omitempty"`
@@ -138,6 +140,8 @@ type RemoteRepository struct {
 	EnableTokenAuthentication         *bool                   `json:"enableTokenAuthentication,omitempty"`
 	ContentSynchronisation            *ContentSynchronisation `json:"contentSynchronisation,omitempty"`
 	BlockPushingSchema1               *bool                   `json:"blockPushingSchema1,omitempty"`
+	QueryParams                       *string                 `json:"queryParams,omitempty"`
+	PropagateQueryParams              *bool                   `json:"propagateQueryParams,omitempty"`
 }
 
 // ContentSynchronisation represents smart remote repository configuration
@@ -175,6 +179,8 @@ type VirtualRepository struct {
 	ExternalDependenciesPatterns                  *[]string `json:"externalDependenciesPatterns,omitempty"`
 	ExternalDependenciesRemoteRepo                *string   `json:"externalDependenciesRemoteRepo,omitempty"`
 	ResolveDockerTagsByTimestamp                  *bool     `json:"resolveDockerTagsByTimestamp,omitempty"`
+	VirtualRetrievalCachePeriodSecs               *int      `json:"virtualRetrievalCachePeriodSecs,omitempty"`
+	DebianDefaultArchitectures                    *string   `json:"debianDefaultArchitectures,omitempty"`
 }
 
 func (v VirtualRepository) String() string {

--- a/artifactory/repositories_test.go
+++ b/artifactory/repositories_test.go
@@ -84,6 +84,7 @@ func Test_Repositories(t *testing.T) {
 					SuppressPomConsistencyChecks: Bool(true),
 					BlackedOut:                   Bool(false),
 					PropertySets:                 &[]string{"artifactory"},
+					ForceNugetAuthentication:     Bool(false),
 				}
 
 				data, _ := ioutil.ReadFile("fixtures/repositories/generic_repository.json")
@@ -111,6 +112,7 @@ func Test_Repositories(t *testing.T) {
 						SuppressPomConsistencyChecks: Bool(false),
 						BlackedOut:                   Bool(false),
 						PropertySets:                 &[]string{"ps1", "ps2"},
+						ForceNugetAuthentication:     Bool(false),
 					},
 					DebianTrivialLayout:             Bool(false),
 					ChecksumPolicyType:              String("client-checksums"),
@@ -152,6 +154,7 @@ func Test_Repositories(t *testing.T) {
 						SuppressPomConsistencyChecks: Bool(false),
 						BlackedOut:                   Bool(false),
 						PropertySets:                 &[]string{"ps1", "ps2"},
+						ForceNugetAuthentication:     Bool(false),
 					},
 					URL:                               String("http://host:port/some-repo"),
 					Username:                          String("remote-repo-user"),
@@ -179,6 +182,7 @@ func Test_Repositories(t *testing.T) {
 					BowerRegistryURL:                  String("https://registry.bower.io"),
 					ComposerRegistryURL:               String("https://packagist.org"),
 					PyPIRegistryURL:                   String("https://pypi.org"),
+					PyPIRepositorySuffix:              String("simple"),
 					VcsType:                           String("GIT"),
 					VcsGitProvider:                    String("CUSTOM"),
 					VcsGitDownloadUrl:                 String(""),
@@ -205,7 +209,9 @@ func Test_Repositories(t *testing.T) {
 							OriginAbsenceDetection *bool `json:"originAbsenceDetection,omitempty"`
 						}{OriginAbsenceDetection: Bool(true)},
 					},
-					BlockPushingSchema1: Bool(true),
+					BlockPushingSchema1:  Bool(true),
+					QueryParams:          String("param1=val1"),
+					PropagateQueryParams: Bool(true),
 				}
 
 				data, _ := ioutil.ReadFile("fixtures/repositories/remote_repository.json")
@@ -219,13 +225,14 @@ func Test_Repositories(t *testing.T) {
 			g.It("- should return valid string for VirtualRepository with String()", func() {
 				actual := &VirtualRepository{
 					GenericRepository: &GenericRepository{
-						Key:             String("virtual-repo1"),
-						RClass:          String("virtual"),
-						PackageType:     String("generic"),
-						Description:     String("The virtual repository public description"),
-						Notes:           String("Some internal notes"),
-						IncludesPattern: String("**/*"),
-						ExcludesPattern: String(""),
+						Key:                      String("virtual-repo1"),
+						RClass:                   String("virtual"),
+						PackageType:              String("generic"),
+						Description:              String("The virtual repository public description"),
+						Notes:                    String("Some internal notes"),
+						IncludesPattern:          String("**/*"),
+						ExcludesPattern:          String(""),
+						ForceNugetAuthentication: Bool(false),
 					},
 					Repositories:        &[]string{"local-repo1", "local-repo2", "remote-repo1", "virtual-repo2"},
 					DebianTrivialLayout: Bool(false),
@@ -238,6 +245,8 @@ func Test_Repositories(t *testing.T) {
 					ExternalDependenciesPatterns:         &[]string{"**/*microsoft*/**", "**/*github*/**"},
 					ExternalDependenciesRemoteRepo:       String(""),
 					ResolveDockerTagsByTimestamp:         Bool(false),
+					DebianDefaultArchitectures:           String("i386,amd64"),
+					VirtualRetrievalCachePeriodSecs:      Int(600),
 				}
 
 				data, _ := ioutil.ReadFile("fixtures/repositories/virtual_repository.json")


### PR DESCRIPTION
### Summary 
This PR  adds the following fields to structs:

GenericRepository: forceNugetAuthentication (bool)
RemoteRepository: queryParams (string), propagateQueryParams (bool), pyPIRepositorySuffix (string)
VirtualRepository: virtualRetrievalCachePeriodSecs (int), debianDefaultArchitectures (string)

