### PR TITLE
Adds metadataRetrievalTimeoutSecs to remote repos

### DIFF
--- a/artifactory/fixtures/repositories/remote_repository.json
+++ b/artifactory/fixtures/repositories/remote_repository.json
@@ -25,6 +25,7 @@
   "retrievalCachePeriodSecs": 43200,
   "failedRetrievalCachePeriodSecs": 30,
   "missedRetrievalCachePeriodSecs": 7200,
+  "metadataRetrievalTimeoutSecs": 60,
   "unusedArtifactsCleanupEnabled": false,
   "unusedArtifactsCleanupPeriodHours": 0,
   "assumedOfflinePeriodSecs" : 300,

--- a/artifactory/repositories.go
+++ b/artifactory/repositories.go
@@ -110,6 +110,7 @@ type RemoteRepository struct {
 	RetrievalCachePeriodSecs          *int                    `json:"retrievalCachePeriodSecs,omitempty" xml:"retrievalCachePeriodSecs,omitempty"`
 	FailedRetrievalCachePeriodSecs    *int                    `json:"failedRetrievalCachePeriodSecs,omitempty" xml:"failedRetrievalCachePeriodSecs,omitempty"`
 	MissedRetrievalCachePeriodSecs    *int                    `json:"missedRetrievalCachePeriodSecs,omitempty" xml:"missedRetrievalCachePeriodSecs,omitempty"`
+	MetadataRetrievalTimeoutSecs      *int                    `json:"metadataRetrievalTimeoutSecs,omitempty" xml:"metadataRetrievalTimeoutSecs,omitempty"`
 	UnusedArtifactsCleanupEnabled     *bool                   `json:"unusedArtifactsCleanupEnabled,omitempty" xml:"unusedArtifactsCleanupEnabled,omitempty"`
 	UnusedArtifactsCleanupPeriodHours *int                    `json:"unusedArtifactsCleanupPeriodHours,omitempty" xml:"unusedArtifactsCleanupPeriodHours,omitempty"`
 	AssumedOfflinePeriodSecs          *int                    `json:"assumedOfflinePeriodSecs,omitempty" xml:"assumedOfflinePeriodSecs,omitempty"`

--- a/artifactory/repositories_test.go
+++ b/artifactory/repositories_test.go
@@ -169,6 +169,7 @@ func Test_Repositories(t *testing.T) {
 					RetrievalCachePeriodSecs:          Int(43200),
 					FailedRetrievalCachePeriodSecs:    Int(30),
 					MissedRetrievalCachePeriodSecs:    Int(7200),
+					MetadataRetrievalTimeoutSecs:      Int(60),
 					UnusedArtifactsCleanupEnabled:     Bool(false),
 					UnusedArtifactsCleanupPeriodHours: Int(0),
 					AssumedOfflinePeriodSecs:          Int(300),


### PR DESCRIPTION
This PR adds a new `metadataRetrievalTimeoutSecs`  property to the remote repository struct per the latest Artifactory release: https://www.jfrog.com/confluence/display/RTF6X/Release+Notes#ReleaseNotes-Artifactory6.23.21